### PR TITLE
Add more metadata from easyeda

### DIFF
--- a/easyeda2kicad/easyeda/easyeda_api.py
+++ b/easyeda2kicad/easyeda/easyeda_api.py
@@ -1,11 +1,13 @@
 # Global imports
 import logging
-
+from typing import Optional
 import requests
 
 from easyeda2kicad import __version__
 
 API_ENDPOINT = "https://easyeda.com/api/products/{lcsc_id}/components?version=6.4.19.5"
+LCSC_PRICES_API_ENDPOINT = "https://easyeda.com/api/getPrices?numbers={lcsc_id}&version=6.5.47"
+JLCPCB_STOCK_API_ENDPOINT = "https://easyeda.com/api/components/getSmtPartInfo?version=6.5.47&numbers={lcsc_id}"
 ENDPOINT_3D_MODEL = "https://modules.easyeda.com/3dmodel/{uuid}"
 ENDPOINT_3D_MODEL_STEP = "https://modules.easyeda.com/qAxj6KHrDKw4blvCG8QJPs7Y/{uuid}"
 # ENDPOINT_3D_MODEL_STEP found in https://modules.lceda.cn/smt-gl-engine/0.8.22.6032922c/smt-gl-engine.js : points to the bucket containing the step files.
@@ -38,7 +40,53 @@ class EasyedaApi:
         cp_cad_info = self.get_info_from_easyeda_api(lcsc_id=lcsc_id)
         if cp_cad_info == {}:
             return {}
-        return cp_cad_info["result"]
+        result = cp_cad_info["result"]
+
+        # Add the current lcsc price
+        lcsc_price = self.get_lcsc_price(lcsc_id=lcsc_id)
+        if lcsc_price:
+            result["lcsc_price"] = lcsc_price
+
+        # Add the current jlcpcb stock
+        stock_num = self.get_jlcpcb_stock(lcsc_id=lcsc_id)
+        if stock_num:
+            result["jlc_stock"] = stock_num        
+
+        return result
+    
+    def get_lcsc_price(self, lcsc_id: str) -> Optional[float]:
+        r = requests.get(url=LCSC_PRICES_API_ENDPOINT.format(lcsc_id=lcsc_id), headers=self.headers)
+        api_response = r.json()
+
+        if not api_response or (
+            api_response.get("success", False) is False
+        ):
+            logging.debug(f"{api_response}")
+            return None
+
+        results = api_response.get("result", [])
+        for result in results:
+            price = result.get("lcsc", {}).get("price")
+            if price:
+                return price
+        logging.warning(f"No price available for {lcsc_id} on LCSC")
+        return None
+
+    def get_jlcpcb_stock(self, lcsc_id: str) -> Optional[int]:
+        r = requests.get(url=JLCPCB_STOCK_API_ENDPOINT.format(lcsc_id=lcsc_id), headers=self.headers)
+        api_response = r.json()
+
+        if not api_response or (
+            api_response.get("success", False) is False
+        ):
+            logging.debug(f"{api_response}")
+            return None
+
+        result = api_response.get("result", {})
+        stock = result.get("stock_num", None)
+        if stock == None:
+            logging.debug(f"No SMT service available for {lcsc_id}")
+        return stock
 
     def get_raw_3d_model_obj(self, uuid: str) -> str:
         r = requests.get(

--- a/easyeda2kicad/easyeda/easyeda_api.py
+++ b/easyeda2kicad/easyeda/easyeda_api.py
@@ -2,15 +2,29 @@
 import logging
 from typing import Optional
 import requests
+from dataclasses import dataclass, field
 
 from easyeda2kicad import __version__
 
 API_ENDPOINT = "https://easyeda.com/api/products/{lcsc_id}/components?version=6.4.19.5"
 LCSC_PRICES_API_ENDPOINT = "https://easyeda.com/api/getPrices?numbers={lcsc_id}&version=6.5.47"
+LCSC_DETAILS_API_ENDPOINT = "https://wmsc.lcsc.com/ftps/wm/product/detail?productCode={lcsc_id}"
 JLCPCB_STOCK_API_ENDPOINT = "https://easyeda.com/api/components/getSmtPartInfo?version=6.5.47&numbers={lcsc_id}"
 ENDPOINT_3D_MODEL = "https://modules.easyeda.com/3dmodel/{uuid}"
 ENDPOINT_3D_MODEL_STEP = "https://modules.easyeda.com/qAxj6KHrDKw4blvCG8QJPs7Y/{uuid}"
 # ENDPOINT_3D_MODEL_STEP found in https://modules.lceda.cn/smt-gl-engine/0.8.22.6032922c/smt-gl-engine.js : points to the bucket containing the step files.
+
+@dataclass
+class LcscDetails:
+    # Manufacturer part number/name
+    lcsc_stock: str = None
+    product_id: str = None
+    parentCategory: str = None
+    category: str = None
+    datasheet: str = None
+    product_description: str = None
+    product_intro: str = None
+    weight: float = None
 
 # ------------------------------------------------------------
 
@@ -50,7 +64,11 @@ class EasyedaApi:
         # Add the current jlcpcb stock
         stock_num = self.get_jlcpcb_stock(lcsc_id=lcsc_id)
         if stock_num:
-            result["jlc_stock"] = stock_num        
+            result["jlc_stock"] = stock_num  
+
+        lcsc_details = self.get_lcsc_details(lcsc_id=lcsc_id)
+        if lcsc_details:
+            result["lcsc_details"] = lcsc_details      
 
         return result
     
@@ -87,6 +105,32 @@ class EasyedaApi:
         if stock == None:
             logging.debug(f"No SMT service available for {lcsc_id}")
         return stock
+
+    def get_lcsc_details(self, lcsc_id: str) -> Optional[float]:
+        r = requests.get(url=LCSC_DETAILS_API_ENDPOINT.format(lcsc_id=lcsc_id), headers=self.headers)
+        api_response = r.json()
+
+        if not api_response or (
+            api_response.get("code", 0) != 200
+        ):
+            logging.debug(f"{api_response}")
+            return None
+
+        result = api_response.get("result", None)
+        if not result:
+            logging.debug(f"No details available for {lcsc_id}")
+            return None
+        
+        return LcscDetails(
+            lcsc_stock=result.get("stockNumber", None),
+            product_id=result.get("productId") and str(result.get("productId")),
+            parentCategory=result.get("parentCatalogName"),
+            category=result.get("catalogName"),
+            datasheet=result.get("pdfUrl", result.get("pdfLinkUrl") or None),
+            product_description=result.get("productDescEn"),
+            product_intro=result.get("productIntroEn"),
+            weight=result.get("weight", result.get("productWeight", None) and (result.get("productWeight", None) / 1000)),
+        )
 
     def get_raw_3d_model_obj(self, uuid: str) -> str:
         r = requests.get(

--- a/easyeda2kicad/easyeda/easyeda_importer.py
+++ b/easyeda2kicad/easyeda/easyeda_importer.py
@@ -175,6 +175,7 @@ class EasyedaSymbolImporter:
                 lcsc_stock=lcsc_details and lcsc_details.lcsc_stock,
                 lcsc_price=lcsc_price,
                 weight=lcsc_details and lcsc_details.weight,
+                properties=(lcsc_details and lcsc_details.properties) or dict(),
             ),
             bbox=EeSymbolBbox(
                 x=float(ee_data["dataStr"]["head"]["x"]),

--- a/easyeda2kicad/easyeda/easyeda_importer.py
+++ b/easyeda2kicad/easyeda/easyeda_importer.py
@@ -137,6 +137,9 @@ class EasyedaSymbolImporter:
         # jlcpcb seems to have a page for every part, but that page does not contain more information than this API call
         jlc_link = f"https://jlcpcb.com/partdetail/{lcsc_number}" if lcsc_number else None
 
+        lcsc_price_raw = ee_data.get("lcsc_price", None)
+        lcsc_price = f"{lcsc_price_raw}$" if lcsc_price_raw != None else None
+
         new_ee_symbol = EeSymbol(
             info=EeSymbolInfo(
                 name=ee_data_info["name"],
@@ -158,6 +161,8 @@ class EasyedaSymbolImporter:
                 manufacturer_part=ee_data_info.get("Manufacturer Part", ee_data_info.get("BOM_Manufacturer Part", None)),
                 category=next(iter(ee_data.get("tags", [])), ""),
                 contributor=ee_data_info.get("Contributor", None),
+                jlc_stock=ee_data.get("jlc_stock", None),
+                lcsc_price=lcsc_price,
             ),
             bbox=EeSymbolBbox(
                 x=float(ee_data["dataStr"]["head"]["x"]),

--- a/easyeda2kicad/easyeda/parameters_easyeda.py
+++ b/easyeda2kicad/easyeda/parameters_easyeda.py
@@ -304,18 +304,16 @@ class EeSymbolInfo:
     # Value of the part, including the unit. What exactly this is is depends on the part.
     # If the part has no value, this is empty
     value: str = ""
-    # # Total stock at lcsc
-    # lcsc_stock: int = 0
-    # # Total stock at szlcsc
-    # szlcsc_stock: int = 0
+    # Total stock at jlcpcb smt service
+    jlc_stock: int = 0
     # 'base' if this is a base part at the jlcpcb SMT service
     # 'expand' if this is an extended part at the jlcpcb SMT service
     # Sometimes empty, not sure what that means
     jlc_class: str = ""
     # 'true' if it is available, 'false' if not, '' if unknown
     jlc_available: str = ""
-    # # Price at jlc
-    # price: str = ""
+    # Price at lcsc
+    lcsc_price: str = ""
     # Name of the supplier. Usually LCSC
     supplier: str = ""
     # Part number as the supplier. Usually equal to name, as lcsc is nearly always the supplier

--- a/easyeda2kicad/easyeda/parameters_easyeda.py
+++ b/easyeda2kicad/easyeda/parameters_easyeda.py
@@ -332,6 +332,8 @@ class EeSymbolInfo:
     display_name: str = ""
     # The weight of a part
     weight: float = None
+    # Additional properties
+    properties: dict = field(default_factory=dict)
 
 
 

--- a/easyeda2kicad/easyeda/parameters_easyeda.py
+++ b/easyeda2kicad/easyeda/parameters_easyeda.py
@@ -306,6 +306,8 @@ class EeSymbolInfo:
     value: str = ""
     # Total stock at jlcpcb smt service
     jlc_stock: int = 0
+    # Total stock at LCSC
+    lcsc_stock: int = 0
     # 'base' if this is a base part at the jlcpcb SMT service
     # 'expand' if this is an extended part at the jlcpcb SMT service
     # Sometimes empty, not sure what that means
@@ -328,6 +330,8 @@ class EeSymbolInfo:
     contributor: str = ""
     # The preferred display name for the part
     display_name: str = ""
+    # The weight of a part
+    weight: float = None
 
 
 

--- a/easyeda2kicad/easyeda/parameters_easyeda.py
+++ b/easyeda2kicad/easyeda/parameters_easyeda.py
@@ -283,13 +283,54 @@ class EeSymbolPath(BaseModel):
 # ---------------- SYMBOL ----------------
 @dataclass
 class EeSymbolInfo:
+    # Manufacturer part number/name
     name: str = ""
+    # Description. Usually empty
+    description: str = ""
+    # Prefix, like C for capacitors or R for resistors
     prefix: str = ""
+    # String describing the manufacturer
     package: str = ""
-    manufacturer: str = ""
+    # Link to the datasheet; Should be a PDF, can be a link to the lcsc store page 
     datasheet: str = ""
+    # Link to the lcsc store page
+    lcsc_link: str = ""
+    # Link to the jlcpcb part page
+    jlc_link: str = ""
+    # The lcsc id. A number in a string. Unique. This is usually not what you want
     lcsc_id: str = ""
-    jlc_id: str = ""
+    # The lcsc number. A C followed by some numbers.
+    lcsc_number: str = ""
+    # Value of the part, including the unit. What exactly this is is depends on the part.
+    # If the part has no value, this is empty
+    value: str = ""
+    # # Total stock at lcsc
+    # lcsc_stock: int = 0
+    # # Total stock at szlcsc
+    # szlcsc_stock: int = 0
+    # 'base' if this is a base part at the jlcpcb SMT service
+    # 'expand' if this is an extended part at the jlcpcb SMT service
+    # Sometimes empty, not sure what that means
+    jlc_class: str = ""
+    # 'true' if it is available, 'false' if not, '' if unknown
+    jlc_available: str = ""
+    # # Price at jlc
+    # price: str = ""
+    # Name of the supplier. Usually LCSC
+    supplier: str = ""
+    # Part number as the supplier. Usually equal to name, as lcsc is nearly always the supplier
+    supplier_part: str = ""
+    # Name of the manufacturer
+    manufacturer: str = ""
+    # The manufacturer part number/name
+    manufacturer_part: str = ""
+    # The category of the part
+    category: str = ""
+    # Who contributed this part. Usually LCSC
+    contributor: str = ""
+    # The preferred display name for the part
+    display_name: str = ""
+
 
 
 @dataclass

--- a/easyeda2kicad/kicad/export_kicad_symbol.py
+++ b/easyeda2kicad/kicad/export_kicad_symbol.py
@@ -303,13 +303,7 @@ def convert_ee_paths(
 def convert_to_kicad(ee_symbol: EeSymbol, kicad_version: KicadVersion) -> KiSymbol:
 
     ki_info = KiSymbolInfo(
-        name=ee_symbol.info.name,
-        prefix=ee_symbol.info.prefix.replace("?", ""),
-        package=ee_symbol.info.package,
-        manufacturer=ee_symbol.info.manufacturer,
-        datasheet=ee_symbol.info.datasheet,
-        lcsc_id=ee_symbol.info.lcsc_id,
-        jlc_id=ee_symbol.info.jlc_id,
+        info = ee_symbol.info,
     )
 
     kicad_symbol = KiSymbol(
@@ -355,7 +349,7 @@ def convert_to_kicad(ee_symbol: EeSymbol, kicad_version: KicadVersion) -> KiSymb
 
 
 def tune_footprint_ref_path(ki_symbol: KiSymbol, footprint_lib_name: str):
-    ki_symbol.info.package = f"{footprint_lib_name}:{ki_symbol.info.package}"
+    ki_symbol.info.info.package = f"{footprint_lib_name}:{ki_symbol.info.info.package}"
 
 
 class ExporterSymbolKicad:

--- a/easyeda2kicad/kicad/parameters_kicad_symbol.py
+++ b/easyeda2kicad/kicad/parameters_kicad_symbol.py
@@ -267,18 +267,20 @@ class KiSymbolInfo:
         append_property(self.info.description, "Description")
         append_property(self.info.jlc_class, "JLCPCB Part Class")
         append_property(self.info.jlc_stock, "JLCPCB Stock")
+        append_property(self.info.lcsc_stock, "LCSC Stock")
         append_property(self.info.lcsc_price, "LCSC Price")
         append_property(self.info.manufacturer, "Manufacturer")
         append_property(self.info.manufacturer_part, "Manufacturer Part")
         append_property(self.info.supplier, "Supplier")
         append_property(self.info.supplier_part, "Supplier Part")
         append_property(self.info.category, "Category")
-        append_property(self.info.contributor, "Contributer")
+        append_property(self.info.contributor, "Contributor")
         append_property(self.info.jlc_available, "JLCPCB SMT Service")
         append_property(self.info.jlc_link, "JLCPCB Part Page")
         append_property(self.info.lcsc_link, "LCSC Page")
         append_property(self.info.lcsc_number, "LCSC Part")
         append_property(self.info.lcsc_id, "LCSC Id")
+        append_property(self.info.weight, "Weight")
 
             
         if self.info.jlc_class:

--- a/easyeda2kicad/kicad/parameters_kicad_symbol.py
+++ b/easyeda2kicad/kicad/parameters_kicad_symbol.py
@@ -244,8 +244,8 @@ class KiSymbolInfo:
             ),
         ]
 
-        current_id = 2
-        def append_property(value: str, name: str):
+        current_id = [2]
+        def append_property(value: str, name: str, id_: int = None):
             nonlocal field_offset_y
             nonlocal current_id
             if value:
@@ -254,14 +254,16 @@ class KiSymbolInfo:
                     property_template.format(
                         key=name,
                         value=value,
-                        id_=2,
+                        id_=id_ or (current_id[0]),
                         pos_y=self.y_low - field_offset_y,
                         font_size=KiExportConfigV6.PROPERTY_FONT_SIZE.value,
                         style="",
                         hide="hide",
                     )
                 )
-                current_id += 1
+            if not id_:
+                current_id[0] = current_id[0] + 1
+                
         append_property(self.info.package, "Footprint")
         append_property(self.info.datasheet, "Datasheet")
         append_property(self.info.description, "Description")
@@ -281,21 +283,9 @@ class KiSymbolInfo:
         append_property(self.info.lcsc_number, "LCSC Part")
         append_property(self.info.lcsc_id, "LCSC Id")
         append_property(self.info.weight, "Weight")
-
-            
-        if self.info.jlc_class:
-            field_offset_y += KiExportConfigV6.FIELD_OFFSET_INCREMENT.value
-            header.append(
-                property_template.format(
-                    key="JLCPCB Part Class",
-                    value=self.info.jlc_class,
-                    id_=6,
-                    pos_y=self.y_low - field_offset_y,
-                    font_size=KiExportConfigV6.PROPERTY_FONT_SIZE.value,
-                    style="",
-                    hide="hide",
-                )
-            )
+        
+        for key, value in self.info.properties.items():
+            append_property(value[1], key, value[0])
 
         return header
 

--- a/easyeda2kicad/kicad/parameters_kicad_symbol.py
+++ b/easyeda2kicad/kicad/parameters_kicad_symbol.py
@@ -266,6 +266,8 @@ class KiSymbolInfo:
         append_property(self.info.datasheet, "Datasheet")
         append_property(self.info.description, "Description")
         append_property(self.info.jlc_class, "JLCPCB Part Class")
+        append_property(self.info.jlc_stock, "JLCPCB Stock")
+        append_property(self.info.lcsc_price, "LCSC Price")
         append_property(self.info.manufacturer, "Manufacturer")
         append_property(self.info.manufacturer_part, "Manufacturer Part")
         append_property(self.info.supplier, "Supplier")
@@ -276,7 +278,8 @@ class KiSymbolInfo:
         append_property(self.info.jlc_link, "JLCPCB Part Page")
         append_property(self.info.lcsc_link, "LCSC Page")
         append_property(self.info.lcsc_number, "LCSC Part")
-        append_property(self.info.lcsc_id, "LCSC Id")        
+        append_property(self.info.lcsc_id, "LCSC Id")
+
             
         if self.info.jlc_class:
             field_offset_y += KiExportConfigV6.FIELD_OFFSET_INCREMENT.value


### PR DESCRIPTION
This PR will add more symbol properties from easyeda and lcsc. For example the datasheet will point to an actual PDF, descriptions are fetched for the parts and the current price and stock are added.

Draft PR because my branch currently also contains an unrelated commit that fixes project relative paths to 3d models.